### PR TITLE
Make engine requirements optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ MySQL & Oracle & PostgreSQL connection pool backends of Django, Be based on SQLA
 
 
 #### Quickstart
-1. Install with `pip`:
+1. Install with `pip` with all engines:
     ```bash
-    $ pip install django-db-connection-pool
+    $ pip install django-db-connection-pool[all]
     ```
+    or select specific engines:
+    ```bash
+    $ pip install django-db-connection-pool[mysql,oracle,postgresql]
+    ```
+    
 
 2. Configuration
     * ##### MySQL  

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,13 @@ def setup():
         install_requires=[
             'Django',
             'SQLAlchemy>=1.2.16',
-            'PyMySQL>=0.9.3',
-            'cx-Oracle>=6.4.1',
-            # 'psycopg2>=2.8.6'
         ],
+        extras_require={
+            'all': ['PyMySQL>=0.9.3', 'cx-Oracle>=6.4.1', 'psycopg2>=2.8.6'],
+            'mysql': ['PyMySQL>=0.9.3'],
+            'oracle': ['cx-Oracle>=6.4.1'],
+            'postgresql': ['psycopg2>=2.8.6'],
+        },
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def setup():
             'SQLAlchemy>=1.2.16',
             'PyMySQL>=0.9.3',
             'cx-Oracle>=6.4.1',
-            'psycopg2>=2.8.6'
+            # 'psycopg2>=2.8.6'
         ],
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I only need the Oracle engine. So I don't want the mysql and postgresql packages to be installed. 
In my case I even cannot install the postgresql because my container lacks some requirements to do so.

Use `extras_require` to specify the engines to be installed. (see changes in readme)