### PR TITLE
Add _set_autocommit to oracle/base.py

### DIFF
--- a/dj_db_conn_pool/backends/oracle/base.py
+++ b/dj_db_conn_pool/backends/oracle/base.py
@@ -13,3 +13,7 @@ class DatabaseWrapper(PooledDatabaseWrapperMixin, base.DatabaseWrapper):
                 return super(OracleDialect, self).do_ping(dbapi_connection)
             except DatabaseError:
                 return False
+
+    def _set_autocommit(self, autocommit):
+        with self.wrap_database_errors:
+            self.connection.dbapi_connection.autocommit = autocommit


### PR DESCRIPTION
Fixes setting the autocommit flag properly when using the oracle backend. Without this fix, autocommit stays false by default even if set to true in Django. See https://github.com/altairbow/django-db-connection-pool/issues/33