### PR TITLE
Support iteration in CursorWrapper

### DIFF
--- a/dj_db_conn_pool/core/utils.py
+++ b/dj_db_conn_pool/core/utils.py
@@ -44,3 +44,6 @@ class CursorWrapper:
             if attr == 'statement':
                 return self._statement
             raise
+
+    def __iter__(self):
+        yield from self._cursor


### PR DESCRIPTION
This PR resolves a bug described in issue #48, which is breaking `v1.2.3`.

It looks like this was introduced in 2383593df44ed68298371c481611b22fdda21904