### PR TITLE
Replace deprecated call to sqlalchemy._ConnectionFairy.connection

### DIFF
--- a/dj_db_conn_pool/backends/postgresql/mixins.py
+++ b/dj_db_conn_pool/backends/postgresql/mixins.py
@@ -13,6 +13,6 @@ class PGDatabaseWrapperMixin(PersistentDatabaseWrapperMixin):
         connection = super().get_new_connection(conn_params)
 
         if not connection.info:
-            connection.info = connection.connection.info
+            connection.info = connection.driver_connection.info
 
         return connection


### PR DESCRIPTION
Quietens a deprecation warning. Tested with sqlalchemy 2.0.19 and 1.4.24 (minimum version currently supported by django-db-connection-pool).

```pytb
../../../envs/django/lib/python3.11/site-packages/pytest_django/fixtures.py:140: in django_db_setup
    db_cfg = setup_databases(
../../../envs/django/lib/python3.11/site-packages/django/test/utils.py:221: in setup_databases
    connection.creation.create_test_db(
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/creation.py:62: in create_test_db
    self._create_test_db(verbosity, autoclobber, keepdb)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/creation.py:199: in _create_test_db
    with self._nodb_cursor() as cursor:
/usr/local/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py:137: in __enter__
    return next(self.gen)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/postgresql/base.py:400: in _nodb_cursor
    with super()._nodb_cursor() as cursor:
/usr/local/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py:137: in __enter__
    return next(self.gen)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/base.py:722: in _nodb_cursor
    with conn.cursor() as cursor:
../../../envs/django/lib/python3.11/site-packages/django/utils/asyncio.py:26: in inner
    return func(*args, **kwargs)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/base.py:330: in cursor
    return self._cursor()
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/base.py:306: in _cursor
    self.ensure_connection()
../../../envs/django/lib/python3.11/site-packages/django/utils/asyncio.py:26: in inner
    return func(*args, **kwargs)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/base.py:289: in ensure_connection
    self.connect()
../../../envs/django/lib/python3.11/site-packages/django/utils/asyncio.py:26: in inner
    return func(*args, **kwargs)
../../../envs/django/lib/python3.11/site-packages/django/db/backends/base/base.py:270: in connect
    self.connection = self.get_new_connection(conn_params)
../../../envs/django/lib/python3.11/site-packages/dj_db_conn_pool/backends/postgresql/base.py:12: in get_new_connection
    connection.info = connection.connection.info
../../../envs/django/lib/python3.11/site-packages/sqlalchemy/util/deprecations.py:385: in warned
    _warn_with_version(message, version, wtype, stacklevel=3)
../../../envs/django/lib/python3.11/site-packages/sqlalchemy/util/deprecations.py:52: in _warn_with_version
    _warnings_warn(warn, stacklevel=stacklevel + 1)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

message = SADeprecationWarning("The _ConnectionFairy.connection attribute is deprecated; please use 'driver_connection' (deprecated since: 2.0)"), category = None, stacklevel = 4

    def _warnings_warn(
        message: Union[str, Warning],
        category: Optional[Type[Warning]] = None,
        stacklevel: int = 2,
    ) -> None:
        # adjust the given stacklevel to be outside of SQLAlchemy
        try:
            frame = sys._getframe(stacklevel)
        except ValueError:
            # being called from less than 3 (or given) stacklevels, weird,
            # but don't crash
            stacklevel = 0
        except:
            # _getframe() doesn't work, weird interpreter issue, weird,
            # ok, but don't crash
            stacklevel = 0
        else:
            stacklevel_found = warning_tag_found = False
            while frame is not None:
                # using __name__ here requires that we have __name__ in the
                # __globals__ of the decorated string functions we make also.
                # we generate this using {"__name__": fn.__module__}
                if not stacklevel_found and not re.match(
                    _not_sa_pattern, frame.f_globals.get("__name__", "")
                ):
                    # stop incrementing stack level if an out-of-SQLA line
                    # were found.
                    stacklevel_found = True
    
                    # however, for the warning tag thing, we have to keep
                    # scanning up the whole traceback
    
                if frame.f_code in _warning_tags:
                    warning_tag_found = True
                    (_suffix, _category) = _warning_tags[frame.f_code]
                    category = category or _category
                    message = f"{message} ({_suffix})"
    
                frame = frame.f_back  # type: ignore[assignment]
    
                if not stacklevel_found:
                    stacklevel += 1
                elif stacklevel_found and warning_tag_found:
                    break
    
        if category is not None:
            warnings.warn(message, category, stacklevel=stacklevel + 1)
        else:
>           warnings.warn(message, stacklevel=stacklevel + 1)
E           sqlalchemy.exc.SADeprecationWarning: The _ConnectionFairy.connection attribute is deprecated; please use 'driver_connection' (deprecated since: 2.0)

../../../envs/django/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py:1895: SADeprecationWarning
```