### PR TITLE
replace dialect class for MySQL

### DIFF
--- a/dj_db_conn_pool/backends/mysql/base.py
+++ b/dj_db_conn_pool/backends/mysql/base.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.db.backends.mysql import base
-from sqlalchemy.dialects.mysql.base import MySQLDialect
+from sqlalchemy.dialects.mysql.mysqldb import MySQLDialect_mysqldb as MySQLDialect
 
 from dj_db_conn_pool.core.mixins import PersistentDatabaseWrapperMixin
 


### PR DESCRIPTION
Replace `sqlalchemy.dialects.mysql.base.MySQLDialect` with `sqlalchemy.dialects.mysql.mysqldb.MySQLDialect_mysqldb`.

close: #61
